### PR TITLE
Create optimized realease binaries

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,3 +24,10 @@ tauri = { git = "https://github.com/probablykasper/tauri", rev = "4c1be45" }
 [features]
 default = [ "custom-protocol" ]
 custom-protocol = [ "tauri/custom-protocol" ]
+
+[profile.release]
+panic = "abort"
+codegen-units = 1
+lto = true
+incremental = false
+opt-level = "s"


### PR DESCRIPTION
This reduced the size of the binary from 6.7MB to 4.5MB